### PR TITLE
Cannot read property 'filter' of null

### DIFF
--- a/src/uiSelectController.js
+++ b/src/uiSelectController.js
@@ -238,7 +238,7 @@ uis.controller('uiSelectCtrl',
       if (ctrl.isEmpty() || (angular.isArray(selectedItems) && !selectedItems.length) || !ctrl.removeSelected) {
         ctrl.setItemsFn(data);
       }else{
-        if ( data !== undefined ) {
+        if ( data !== undefined && data !== null ) {
           var filteredItems = data.filter(function(i) {
             return selectedItems.every(function(selectedItem) {
               return !angular.equals(i, selectedItem);


### PR DESCRIPTION
fix(uiSelectCtrl): change condition that checks if data is empty before applying filter

Error `Cannot read property 'filter' of null` occurs after initializing select
